### PR TITLE
Add first pass of OSA residuals

### DIFF
--- a/R/dsem.R
+++ b/R/dsem.R
@@ -133,11 +133,14 @@ function( sem,
     stop("Some variable in `sem` is not in `tsdata`")
   }
 
-  #
+  ## get observations into format applicable for OSA
+  ## residuals. This is a single vector with NAs removed
+  y_k2 <- as.numeric(na.omit(as.numeric(tsdata)))
   Data = list( "RAM" = as.matrix(na.omit(ram[,1:4])),
                "RAMstart" = as.numeric(ram[,5]),
                "familycode_j" = sapply(family, FUN=switch, "fixed"=0, "normal"=1 ),
-               "y_tj" = tsdata )
+              "y_tj" = tsdata,
+              "y_k2"= y_k2)
 
   # Construct parameters
   if( is.null(control$parameters) ){


### PR DESCRIPTION
This implements one-step-ahead residuals for observed data families except "binomial" and "fixed." The former could be implemented using a `pbeta` approach as in other applications, e.g., [here](https://github.com/search?q=repo%3Atimjmiller%2Fwham%20pbinom&type=code). 

OSA residuals can be determined as normal by calling

`TMB::oneStepPredict(fit$obj, data.term.indicator='keep', observation.name='y_k2')`

where `fit` is returned by the `dsem` function, and selecting one of the available methods (see `?oneStepPredict`). The 'cdf' method is probably the best choice although for fast models the 'oneStepGeneric' should provide more accurate estimates. Note that residuals make no sense for "fixed" family and if the observation error is estimated to be very small it will likely fail as well. 

All tests passed and the package and vignettes were built locally without issue, but should be considered an experimental feature for now. Further testing would be prudent, in particular comparing an equivalent model to a existing framework with OSA implemented to ensure they match and thus confirm it has been correctly coded in `dsem`.