### PR TITLE
Parse SEM with all fixed coefficients

### DIFF
--- a/R/make_matrices.R
+++ b/R/make_matrices.R
@@ -51,7 +51,7 @@ function( beta_p,
   # Assemble
   IminusP_kk = AD(I_kk - P_kk)
   invV_kk = AD(G_kk)
-  invV_kk@x = 1 / G_kk@x^2
+  invV_kk@x = AD(1 / G_kk@x^2)
   #Q_kk = t(IminusP_kk) %*% invV_kk %*% IminusP_kk
 
   out = list(

--- a/R/read_model.R
+++ b/R/read_model.R
@@ -38,11 +38,11 @@ function( sem,
           paths[i] <- paste(variables[i], "<->", variables[i])
           par.names[i] <- paste("V[", variables[i], "]", sep = "")
       }
-      model.2 <- cbind(
-        'path' = c(model[, 1], paths),
-        'lag' = c(model[,2], rep(0,nvars)),
-        'name' = c(model[, 3], par.names),
-        'start' = c(model[, 4], rep(NA, length(paths))) )
+      model.2 <- data.frame(
+        'path' = c(model$paths, paths),
+        'lag' = c(model$lag, rep(0,nvars)),
+        'name' = c(model$name, par.names),
+        'start' = c(model$start, rep(NA, length(paths))) )
       model.2
   }
   need.variance <- function() {
@@ -118,6 +118,7 @@ function( sem,
   pars = na.omit(unique(par.names))
   par.nos = apply(outer(pars, par.names, "=="), 2, which)
   par.nos = unlist(sapply( par.nos, FUN=\(x) ifelse(length(x)==0, 0, x) ))
+  if (is.null(par.nos)) par.nos = rep(0, nrow(model))
   model = cbind( model, "parameter"=par.nos )
 
   # Add incidence to model


### PR DESCRIPTION
+ small change to `read_model` - previously, returned a matrix if missing covariances needed to be added, now returns data frame regardless.