### PR TITLE
teeny fix to read_model

### DIFF
--- a/R/read_model.R
+++ b/R/read_model.R
@@ -39,7 +39,7 @@ function( sem,
           par.names[i] <- paste("V[", variables[i], "]", sep = "")
       }
       model.2 <- data.frame(
-        'path' = c(model$paths, paths),
+        'path' = c(model$path, paths),
         'lag' = c(model$lag, rep(0,nvars)),
         'name' = c(model$name, par.names),
         'start' = c(model$start, rep(NA, length(paths))) )


### PR DESCRIPTION
This is a very silly pull request - `model$paths` instead of `model$path` in `read_model` causes problems when adding missing variance parameters. All tests pass on my local machine, of course.